### PR TITLE
fix(queue): always close eclient conn if it exists

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -195,7 +195,7 @@ class Queue extends Emitter {
       if (this.settings.quitCommandClient) {
         clients.push(this.client);
       }
-      if (this.settings.getEvents) {
+      if (this.eclient) {
         clients.push(this.eclient);
       }
 


### PR DESCRIPTION
Before, the eclient was created if this was true (see line 77):

```
this.settings.getEvents || this.settings.activateDelayedJobs
```

But then it was closed iff `this.settings.getEvents` was true, which
meant that `close()` would fail to terminate all connections if the
settings were `{ getEvents: false, activateDelayedJobs: true }`.